### PR TITLE
Security: Dependabot findings.

### DIFF
--- a/.github/workflows/on.pr.yml
+++ b/.github/workflows/on.pr.yml
@@ -21,8 +21,9 @@ jobs:
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Set up JDK 18
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
+          distribution: 'corretto'
           java-version: 18
       - uses: actions/cache@v4
         with:

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -39,12 +39,12 @@
         <maven.compiler.version>3.10.1</maven.compiler.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <org.mapstruct.version>1.5.2.Final</org.mapstruct.version>
-        <springdoc.version>1.6.9</springdoc.version>
+        <org.mapstruct.version>1.6.3</org.mapstruct.version>
+        <springdoc.version>1.6.11</springdoc.version>
         <shedlock.version>4.39.0</shedlock.version>
         <nats.version>2.11.0</nats.version>
         <guava.version>33.4.0-jre</guava.version>
-        <log4j.version>2.18.0</log4j.version>
+        <log4j.version>2.24.3</log4j.version>
         <resilience4j.version>1.7.1</resilience4j.version>
     </properties>
 

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -41,9 +41,9 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <org.mapstruct.version>1.5.2.Final</org.mapstruct.version>
         <springdoc.version>1.6.9</springdoc.version>
-        <shedlock.version>4.20.0</shedlock.version>
+        <shedlock.version>4.39.0</shedlock.version>
         <nats.version>2.11.0</nats.version>
-        <guava.version>30.1.1-jre</guava.version>
+        <guava.version>33.4.0-jre</guava.version>
         <log4j.version>2.18.0</log4j.version>
         <resilience4j.version>1.7.1</resilience4j.version>
     </properties>
@@ -278,7 +278,7 @@
                 <plugin>
                     <groupId>org.hibernate.orm.tooling</groupId>
                     <artifactId>hibernate-enhance-maven-plugin</artifactId>
-                    <version>6.1.1.Final</version>
+                    <version>6.6.4.Final</version>
                 </plugin>
                 <plugin>
                     <groupId>org.springframework.boot</groupId>
@@ -368,7 +368,7 @@
                     <plugin>
                         <groupId>org.hibernate.orm.tooling</groupId>
                         <artifactId>hibernate-enhance-maven-plugin</artifactId>
-                        <version>6.1.1.Final</version>
+                        <version>6.6.4.Final</version>
                         <executions>
                             <execution>
                                 <configuration>


### PR DESCRIPTION
Change Details:
- Bump org.hibernate.orm.tooling:hibernate-enhance-maven-plugfrom 6.1.1.Final to 6.6.4.Final 
- Bump com.google.guava:guava from 30.1.1-jre to 33.4.0-jre 
- Bump shedlock.version from 4.20.0 to 4.39.0 
- Bump springdoc.version from 1.6.9 to 1.6.11 
- Bump org.apache.logging.log4j:log4j-to-slf4j from 2.18.0 to 2.24.3
- Bump org.mapstruct.version from 1.5.2.Final to 1.6.3 